### PR TITLE
Implemented ILogger.BeginScope

### DIFF
--- a/src/apache.log4net.Extensions.Logging/AggregatedDisposable.cs
+++ b/src/apache.log4net.Extensions.Logging/AggregatedDisposable.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace apache.log4net.Extensions.Logging
+{
+    /// <summary>
+    /// Combines multiple <see cref="IDisposable"/>s into one.
+    /// </summary>
+    internal sealed class AggregatedDisposable : IDisposable
+    {
+        /// <summary>
+        /// The combined <see cref="IDisposable"/>s.
+        /// </summary>
+        private readonly ICollection<IDisposable> _disposables;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AggregatedDisposable"/> class.
+        /// </summary>
+        /// <param name="disposables">The <see cref="IDisposable"/> which should be combined.</param>
+        public AggregatedDisposable(IEnumerable<IDisposable> disposables)
+        {
+            this._disposables = disposables.ToList();
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            foreach (var disposable in this._disposables)
+            {
+                disposable.Dispose();
+            }
+
+            this._disposables.Clear();
+        }
+    }
+}

--- a/src/apache.log4net.Extensions.Logging/Log4NetLogger.cs
+++ b/src/apache.log4net.Extensions.Logging/Log4NetLogger.cs
@@ -1,5 +1,7 @@
 ﻿using log4net;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using log4net.Core;
 using Microsoft.Extensions.Logging;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
@@ -18,6 +20,15 @@ namespace apache.log4net.Extensions.Logging
 
         public IDisposable BeginScope<TState>(TState state)
         {
+            var pairs = state as IEnumerable<KeyValuePair<string, object>>;
+            var tuples = state as IEnumerable<(string, object)>;
+            var disposables = pairs?.Select(pair => ThreadContext.Stacks[pair.Key].Push(pair.Value.ToString()))
+                              ?? tuples?.Select(pair => ThreadContext.Stacks[pair.Item1].Push(pair.Item2.ToString()));
+            if (disposables != null)
+            {
+                return new AggregatedDisposable(disposables);
+            }
+
             return null;
         }
 


### PR DESCRIPTION
Scopes are added to the log4net ThreadContext, if the value is IEnumerable<KeyValuePair<string, object>>. This is a convention of the Serilog provider as well, see here: https://nblumhardt.com/2016/11/ilogger-beginscope/

As a bonus, it also supports IEnumerable of (string, object) tuples.